### PR TITLE
Fix usage of tolist in graph_classification/util.py

### DIFF
--- a/graph_classification/util.py
+++ b/graph_classification/util.py
@@ -80,8 +80,14 @@ def load_data():
     print('# classes: %d' % cmd_args.num_class)
     print('# node features: %d' % cmd_args.feat_dim)
 
-    train_idxes = np.loadtxt('./data/%s/10fold_idx/train_idx-%d.txt' % (cmd_args.data, cmd_args.fold), dtype=np.int32).tolist()
-    test_idxes = np.loadtxt('./data/%s/10fold_idx/test_idx-%d.txt' % (cmd_args.data, cmd_args.fold), dtype=np.int32).tolist()
+    train_data = np.loadtxt('./data/%s/10fold_idx/train_idx-%d.txt' % (cmd_args.data, cmd_args.fold), dtype=np.int32)
+    test_data = np.loadtxt('./data/%s/10fold_idx/test_idx-%d.txt' % (cmd_args.data, cmd_args.fold), dtype=np.int32)
+    train_idxes = train_data.tolist()
+    test_idxes = test_data.tolist()
+    if train_data.ndim == 0:
+        train_idxes = [train_idxes]
+    if test_data.ndim == 0:
+        test_idxes = [test_idxes]
 
     return [g_list[i] for i in train_idxes], [g_list[i] for i in test_idxes]
     


### PR DESCRIPTION
Currently the way tolist is used, it will not yield an array
if the train and test files only have 1 index in them. This
causes python to throw a type error saying that you can't index
a scalar value.
This will most likely not happen in practice but is still a bug.